### PR TITLE
Fix broken using lastest node-inspector

### DIFF
--- a/bin/node-debug.js
+++ b/bin/node-debug.js
@@ -1,20 +1,16 @@
 #!/usr/bin/env node
-var DebugServer = require('node-inspector/lib/debug-server');
+var DebugServer = require('node-inspector/lib/debug-server').DebugServer;
+var config = require('node-inspector/lib/config');
 var spawn = require('child_process').spawn;
 var open = require('open');
 
-spawn('node', ['--debug-brk'].concat(process.argv.slice(2)));
-
 var debugServer = new DebugServer();
-
 debugServer.on('close', function () {
   console.log('session closed');
   process.exit();
 });
+debugServer.start(config);
 
-debugServer.start({
-  webPort: 8080,
-  debugPort: 5858
-});
+spawn('node', ['--debug-brk'].concat(process.argv.slice(2)));
 
-open('http://localhost:8080/debug?port=5858');
+open('http://localhost:' + config.webPort + '/debug?port=' + config.debugPort);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-debug",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Quick and easy wrapper for node-inspector",
   "bin": {
     "node-debug": "bin/node-debug.js"
@@ -10,8 +10,8 @@
   },
   "repository": "http://github.com/jfirebaugh/node-debug",
   "dependencies": {
-    "node-inspector": "0",
-    "open": "0"
+    "node-inspector": "~0.6.2",
+    "open": "~0.0.4"
   },
   "author": {
     "name": "John Firebaugh",


### PR DESCRIPTION
This version of node-debug is broken, can you merge this pr and publish a new version.
1. use lastest node-inspector, and change it's version
2. use node-inspector's config ,so I can use it's specify webPort #1
